### PR TITLE
Links to social networks now open a new tab

### DIFF
--- a/dossier-demo/a-propos.html
+++ b/dossier-demo/a-propos.html
@@ -20,8 +20,8 @@
         <li>Développement</li>
     </ul>
     <a href="../index.html">Retour à l'accueil</a>
-    <a href="https://twitter.com/">Twitter</a>
-    <a href="https://www.instagram.com/">Instagram</a>
+    <a target="_blank" href="https://twitter.com/">Twitter</a>
+    <a target="_blank" href="https://www.instagram.com/">Instagram</a>
 </body>
 
 </html>


### PR DESCRIPTION
Sometimes opening Instagram removes the ability to go back to the webpage, this fixes the issue